### PR TITLE
Update instructor and helper team, workshop title and registration link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,7 +47,7 @@ flavor: "r"
 # Most workshops don't use extra pages. More information about extra
 # pages are included in the README:
 # https://github.com/carpentries/workshop-template#creating-extra-pages
-title: "Leiden & Delft Data Carpentry"
+title: "Data Carpentry for Social Sciences"
 
 #------------------------------------------------------------
 # Pilot workshop settings (only relevant for lesson pilots).

--- a/index.md
+++ b/index.md
@@ -13,11 +13,11 @@ humandate: "Jul 5-8, 2021"    # human-readable dates for the workshop (e.g., "Fe
 humantime: "9:00 am - 1:00 pm"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: 2021-07-05      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2021-07-08        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
-instructor: ["Ben Companjen", "Peter Verhaar", "Kristina Hettne", "Jeff Love"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
-helper: ["Eirini Zormpa", "tba"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
+instructor: ["Ben Companjen", "Peter Verhaar", "Kristina Hettne", "Esther Plomp", "Bjorn Bartholdy"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
+helper: ["Eirini Zormpa", "Claudiu Forgaci", "Jeff Love", "Ben Companjen", "Peter Verhaar", "Kristina Hettne", "Esther Plomp", "Bjorn Bartholdy"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["t.f.deroo@library.leidenuniv.nl"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes:  # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
-eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
+eventbrite:  "156581007007"  # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 
 {% comment %} See instructions in the comments below for how to edit specific sections of this workshop template. {% endcomment %}


### PR DESCRIPTION
Based on discussion on 9 June, I used the more generic title and added the names of helpers, including the instructors' names when they also act as helpers.

I added the link to Eventbrite for registration.